### PR TITLE
Sending InternalServerError from catch blocks of the api-controller.

### DIFF
--- a/src/Products/Editor/Controllers/EditorApiController.cs
+++ b/src/Products/Editor/Controllers/EditorApiController.cs
@@ -100,7 +100,7 @@ namespace GroupDocs.Editor.MVC.Products.Editor.Controllers
             }
             catch (System.Exception ex)
             {
-                return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex));
+                return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex));
             }
         }
 
@@ -233,7 +233,7 @@ namespace GroupDocs.Editor.MVC.Products.Editor.Controllers
             catch (System.Exception ex)
             {
                 // set exception message
-                return Request.CreateResponse(HttpStatusCode.OK, new Resources().GenerateException(ex));
+                return Request.CreateResponse(HttpStatusCode.InternalServerError, new Resources().GenerateException(ex));
             }
         }
 


### PR DESCRIPTION
**Problem:**
It would be better to response with `InternalServerError` status from the catch blocks of the api-controller.

**Solution:**
`OK` status was replaced by `InternalServerError` in the catch blocks of the api-controller.

**Tests:**
Build&run the project, check that it works as expected.